### PR TITLE
Remove duplicate Node.js installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,6 @@ RUN apt-get update && apt-get install -y \
     nodejs \
     npm \
     software-properties-common \
-    nodejs \
-    npm \
     cargo \
     build-essential \
     curl \


### PR DESCRIPTION
## Summary
- ensure `nodejs` and `npm` are listed only once in the Dockerfile's apt-get install list

## Testing
- `docker build . -t solidity-mcp-server-test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a891e71f20832da676907ef5fad966