### PR TITLE
Add procps to Dockerfile for Homebrew

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     curl \
     file \
     git \
+    procps \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Solidity compiler


### PR DESCRIPTION
## Summary
- Install `procps` package in Docker image to provide `ps` and related utilities needed by Homebrew installer

## Testing
- `docker build -t mcp-test .` *(fails: command not found: docker)*
- `apt-get update` *(fails: repository 403 Forbidden, unable to install docker)*

------
https://chatgpt.com/codex/tasks/task_e_68a891e60b34832da401cf67d32c94e2