### PR TITLE
Expose MCP tools at root endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,21 +90,19 @@ TOOLS_SCHEMA = [
 # MCP Protocol endpoints
 @app.get("/")
 async def root():
+    """Return server information and tool definitions."""
     return {
-        "jsonrpc": "2.0",
-        "result": {
-            "protocolVersion": "2024-11-05",
-            "capabilities": {
-                "tools": {
-                    "listChanged": True
-                }
-            },
-            "serverInfo": {
-                "name": "solidity-mcp",
-                "version": "1.0.0"
-            },
-            "tools": TOOLS_SCHEMA
-        }
+        "protocolVersion": "2024-11-05",
+        "capabilities": {
+            "tools": {
+                "listChanged": True
+            }
+        },
+        "serverInfo": {
+            "name": "solidity-mcp",
+            "version": "1.0.0"
+        },
+        "tools": TOOLS_SCHEMA,
     }
 
 @app.post("/")


### PR DESCRIPTION
## Summary
- return server info and tool definitions directly from `/`

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac5edaec54832d9d9b35a3c2b9a3af