### PR TITLE
Fix SSE and tool initialization for Solidity MCP

### DIFF
--- a/main.py
+++ b/main.py
@@ -116,6 +116,7 @@ async def sse_stream():
     """Stream asynchronous notifications via Server-Sent Events."""
 
     async def event_generator():
+        yield ": ready\n\n"
         while True:
             try:
                 message = await asyncio.wait_for(
@@ -125,7 +126,14 @@ async def sse_stream():
             except asyncio.TimeoutError:
                 yield ": keep-alive\n\n"
 
-    return StreamingResponse(event_generator(), media_type="text/event-stream")
+    headers = {
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+    }
+
+    return StreamingResponse(
+        event_generator(), media_type="text/event-stream", headers=headers
+    )
 
 @app.post("/")
 async def handle_mcp_request(request: Request):
@@ -152,7 +160,8 @@ async def handle_mcp_request(request: Request):
                     "serverInfo": {
                         "name": "solidity-mcp",
                         "version": "1.0.0"
-                    }
+                    },
+                    "tools": TOOLS_SCHEMA,
                 }
             }
             print("Sending initialize response")


### PR DESCRIPTION
## Summary
- ensure `/sse` endpoint streams with initial ready event and keep-alive headers
- return full tool list during `initialize` so clients immediately know available tools

## Testing
- `pip install -r requirements.txt` *(fails: Cannot connect to proxy)*
- `python3 -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac903ff50c832d9b7bc7043f66d186